### PR TITLE
Emit event "complete" instead of passing callback onComplete

### DIFF
--- a/src/ScratchCard.vue
+++ b/src/ScratchCard.vue
@@ -54,7 +54,6 @@ export default {
     cardHeight: Number,
     finishPercent: Number,
     forceReveal: Boolean,
-    onComplete: Function,
   },
 
   data() {
@@ -145,7 +144,7 @@ export default {
     reveal() {
       if (!this.isFinished) {
         this.canvas.parentNode.removeChild(this.canvas);
-        if (this.onComplete) this.onComplete();
+        this.$emit("complete");
       }
       this.isFinished = true;
     },


### PR DESCRIPTION
Emitting custom events is more declarative and the "Vue" way.

Docs source: https://vuejs.org/v2/guide/components-custom-events.html

So in the end the user will get something like this:
`<scratch-card @complete="triggerAlert()" ...>...</scratch-card>`